### PR TITLE
Fix static asset paths

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -125,11 +125,11 @@ Smartphone Compatible web template, free webdesigns for Nokia, Samsung, LG, Sony
 	<!-- css files -->
 	<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
 		integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
-	<link href="{{ url_for('static', filename='static/css/bootstrap.css') }}" rel='stylesheet' type='text/css' />
+        <link href="{{ url_for('static', filename='css/bootstrap.css') }}" rel='stylesheet' type='text/css' />
 	<!-- bootstrap css -->
-	<link href="{{ url_for('static', filename='static/css/style.css') }}" rel='stylesheet' type='text/css' />
+        <link href="{{ url_for('static', filename='css/style.css') }}" rel='stylesheet' type='text/css' />
 	<!-- custom css -->
-	<link href="{{ url_for('static', filename='static/css/font-awesome.min.css') }}" rel="stylesheet">
+        <link href="{{ url_for('static', filename='css/font-awesome.min.css') }}" rel="stylesheet">
 	<!-- //css files -->
 	 <link rel="icon" type="image/png" href="{{ url_for('static', filename='images/favicon.png?') }}"> 
 


### PR DESCRIPTION
## Summary
- correct CSS paths in `layout.html`

## Testing
- `python test_server.py` (custom Flask server to render templates)
- `curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:5001/static/css/bootstrap.css`

------
https://chatgpt.com/codex/tasks/task_e_686bfb0c70508323846d722ab37972c4