### PR TITLE
Improve robustness of AgroBot prediction workflows

### DIFF
--- a/templates/disease.html
+++ b/templates/disease.html
@@ -26,6 +26,12 @@
   
 
 
+  {% if error %}
+  <div class="alert alert-danger" role="alert">
+    {{ error }}
+  </div>
+  {% endif %}
+
   <form class="form-signin" method=post enctype=multipart/form-data>
 
     <h2 class="h4 mb-3 font-weight-normal"><b>Please Upload The Image</b></h2>


### PR DESCRIPTION
## Summary
- harden weather fetching by adding request error handling and validating API responses before use
- guard plant disease inference against unreadable images and missing disease metadata while running inference without gradients
- validate fertilizer crop lookups and surface friendly error messages in the UI when issues occur

## Testing
- python -m compileall App

------
https://chatgpt.com/codex/tasks/task_e_68e16f30fee88323b9722bbc94a5fcc0